### PR TITLE
SAK-6 Finalize cart model

### DIFF
--- a/core/cart/constants.py
+++ b/core/cart/constants.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+SAFE_ACTIONS: Literal['list', 'retrieve'] = [
+    'list',
+    'retrieve'
+]
+PRIVATE_ACTIONS: Literal['create', 'update', 'partial_update', 'destroy'] = [
+    'create',
+    'update',
+    'partial_update',
+    'destroy'
+]

--- a/core/cart/models.py
+++ b/core/cart/models.py
@@ -1,5 +1,8 @@
 from django.db import models
 
+from rest_framework.exceptions import APIException
+from rest_framework import status
+
 from product.models import Product
 
 from user.models import User
@@ -11,6 +14,11 @@ class Cart(models.Model):
                                    on_delete=models.SET_NULL,
                                    null=True,
                                    blank=False)
+
+    def clean(self):
+        if not self.cart_owner:
+            raise APIException("Cart owner must be specified.",
+                               code=status.HTTP_400_BAD_REQUEST)
 
     def __str__(self):
         return f'Cart: {self.id} | Owner: [email: {self.cart_owner.email} - ID: {self.cart_owner.id}]'  # NOQA
@@ -34,6 +42,17 @@ class CartItem(models.Model):
                                            default=1,
                                            null=True,
                                            blank=True)
+
+    def clean(self):
+        if not self.cart:
+            raise APIException("Cart must be specified.",
+                               code=status.HTTP_400_BAD_REQUEST)
+        if not self.product:
+            raise APIException("Product must be specified.",
+                               code=status.HTTP_400_BAD_REQUEST)
+        if self.quantity <= 0:
+            raise APIException("Quantity must be a positive number.",
+                               code=status.HTTP_400_BAD_REQUEST)
 
     def __str__(self):
         _product_title = self.product.title

--- a/core/cart/serializers.py
+++ b/core/cart/serializers.py
@@ -4,7 +4,7 @@ from cart.models import Cart, CartItem
 
 
 class CartItemSerializer(serializers.ModelSerializer):
-
+    product_url = serializers.HyperlinkedRelatedField(view_name='product-detail', read_only=True, source='product')  # NOQA
     cart_item_url = serializers.HyperlinkedIdentityField(view_name='cart-item-detail')  # NOQA
 
     class Meta:
@@ -17,11 +17,11 @@ class CartItemSerializer(serializers.ModelSerializer):
         return representation
 
 
-class _CustomCartItemSerializer(serializers.ModelSerializer):
+class _CustomCartItemSerializer(CartItemSerializer):
 
     class Meta:
         model = CartItem
-        fields = ['product']
+        fields = ['product', 'product_url', 'cart_item_url']
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)

--- a/core/cart/views.py
+++ b/core/cart/views.py
@@ -1,7 +1,12 @@
 from rest_framework import viewsets, permissions
+from rest_framework.response import Response
+from rest_framework.exceptions import APIException
+from django.http.request import HttpRequest
 
 from cart.serializers import CartSerializer, CartItemSerializer
 from cart.models import Cart, CartItem
+from components.cart.validators import CartItemValidator, CartValidator
+from cart import constants
 
 
 class CartViewSet(viewsets.ModelViewSet):
@@ -9,8 +14,42 @@ class CartViewSet(viewsets.ModelViewSet):
     serializer_class = CartSerializer
     permission_classes = [permissions.AllowAny]
 
+    def get_permissions(self) -> list[permissions.BasePermission]:
+        if self.action in constants.SAFE_ACTIONS:
+            return [permissions.AllowAny()]
+        elif self.action in constants.PRIVATE_ACTIONS:
+            return [permissions.IsAuthenticated()]
+        else:
+            return []
+
+    def create(self, request: HttpRequest, *args, **kwargs) -> Response:
+        validator = CartValidator(request)
+
+        result = validator.validate_cart_creation()
+        if isinstance(result, str):
+            raise APIException(result)
+
+        return super().create(request, *args, **kwargs)
+
 
 class CartItemViewSet(viewsets.ModelViewSet):
     queryset = CartItem.objects.all()
     serializer_class = CartItemSerializer
     permission_classes = [permissions.AllowAny]
+
+    def get_permissions(self) -> list[permissions.BasePermission]:
+        if self.action in constants.SAFE_ACTIONS:
+            return [permissions.AllowAny()]
+        elif self.action in constants.PRIVATE_ACTIONS:
+            return [permissions.IsAuthenticated()]
+        else:
+            return []
+
+    def create(self, request: HttpRequest, *args, **kwargs) -> Response:
+        validator = CartItemValidator(request)
+
+        result = validator.validate_cart_item_creation()
+        if isinstance(result, str):
+            raise APIException(result)
+
+        return super().create(request, *args, **kwargs)

--- a/core/components/cart/validators.py
+++ b/core/components/cart/validators.py
@@ -1,0 +1,91 @@
+from typing import Literal
+
+from django.http.request import HttpRequest
+
+from product.models import Product
+from cart.models import Cart
+from user.models import User
+
+
+class CartItemValidator:
+    error_messages = {
+        "high_quantity": "You can't add %(quantity)s of %(product)s, only %(quantity_in_stock)s left.",
+        "already_in_cart": "%(product)s is already in your cart.",
+    }
+
+    def __init__(self, request: HttpRequest) -> None:
+        self.request = request
+        self.cart_id = request.POST.get('cart')
+        self.product_id = request.POST.get('product')
+        self.quantity = int(request.POST.get('quantity'))
+
+    def validate_cart_item_creation(self) -> str | Literal[True]:
+        """
+        Validate cart item creation
+
+        You can create cart item only if it quantity >= of product quantity in stock
+        """
+        if not (result := self._validate_cart_not_exists()):
+            return result
+
+        product = Product.objects.get(id=self.product_id)
+        quantity_in_stock = int(product.quantity_in_stock)
+        if quantity_in_stock < self.quantity:
+            return self.error_messages['high_quantity'] % {
+                "quantity": self.quantity,
+                "product": product.title,
+                "quantity_in_stock": quantity_in_stock
+            }
+
+        return self._validate_item_not_in_cart(product)
+
+    def _validate_item_not_in_cart(self, product: Product) -> str | Literal[True]:
+        cart = Cart.objects.get(id=self.cart_id)
+        products_in_cart = cart.cartitem_set.all().values_list('product__id', flat=True)
+        products_in_cart_list = list(products_in_cart)
+
+        if product.id in products_in_cart_list:
+            return self.error_messages['already_in_cart'] % {
+                "product": product.title
+            }
+
+        return True
+
+
+class CartValidator:
+    error_messages = {
+        "cart_exists": "Cart of user '%(user)s' already exists.",
+        "no_cart_owner": "User 'ID: %(id)s' does not exists and can't be assigned as cart owner."
+    }
+
+    def __init__(self, request: HttpRequest) -> None:
+        self.request = request
+        self.cart_owner_id = request.data['cart_owner']
+
+    def validate_cart_creation(self):
+        if isinstance(result := self._validate_cart_owner_exists(), str):
+            return result
+
+        if isinstance(result := self._validate_cart_not_exists(), str):
+            return result
+
+    def _validate_cart_owner_exists(self):
+        if not self.__get_cart_owner_email():
+            return self.error_messages['no_cart_owner'] % {
+                "id": self.cart_owner_id
+            }
+
+    def _validate_cart_not_exists(self) -> str | Literal[True]:
+        cart_owner_email = self.__get_cart_owner_email()
+        if Cart.objects.get(cart_owner=self.cart_owner_id):
+            return self.error_messages['cart_exists'] % {
+                "user": cart_owner_email
+            }
+        return True
+
+    def __get_cart_owner_email(self) -> str:
+        try:
+            cart_owner = User.objects.get(id=self.cart_owner_id)
+            return cart_owner.email
+        except User.DoesNotExist:
+            return False


### PR DESCRIPTION
- Added clean() methods for Cart and CartItem models
- Added product_url displaying in CartItemSerializer (useful if you want to get more info about product itself)
- Views:
    - Permissions:
        - AllowAny: list(GET), retrieve(GET)
        - IsAuthenticated: create(POST), update(PUT), partial_update(PATCH), destroy(DELETE)
    - Cart and CartItem creation validates now:
        - Cart: You can't create cart if it already exists or user(cart_owner) does not exists
        - CartItem: You can't create cartitem if it quantity higher than product available quantity_in_stock or if product already in cart
        - Provided error messages for all of this cases